### PR TITLE
fix(alpha): Use peer flag for setting peer addresses.

### DIFF
--- a/outserv/cmd/alpha/run.go
+++ b/outserv/cmd/alpha/run.go
@@ -775,7 +775,7 @@ func run() {
 
 	raft := z.NewSuperFlag(Alpha.Conf.GetString("raft")).MergeAndCheckDefault(worker.RaftDefaults)
 	x.WorkerConfig = x.WorkerOptions{
-		PeerAddr:            strings.Split(Alpha.Conf.GetString("zero"), ","),
+		PeerAddr:            strings.Split(Alpha.Conf.GetString("peer"), ","),
 		Raft:                raft,
 		WhiteListedIPRanges: ips,
 		StrictMutations:     opts.MutationsMode == worker.StrictMutations,


### PR DESCRIPTION
In #14 Zero was moved to Alpha with the addition of the "peer" flag.

This change uses the flag instead of the removed "zero" flag.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/outserv/19)
<!-- Reviewable:end -->
