### PR TITLE
chore(jemalloc): Use a suffix for jemalloc install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/outcaste-io/dgo/v210 v210.0.0-20220225180226-43bd1b427e86
 	github.com/outcaste-io/gqlgen v0.13.3
 	github.com/outcaste-io/gqlparser/v2 v2.2.3
-	github.com/outcaste-io/ristretto v0.1.1-0.20220401002559-4aa2153b8411
+	github.com/outcaste-io/ristretto v0.1.1-0.20220404164505-73809bc14974
 	github.com/outcaste-io/sroar v0.0.0-20220207092908-fa5c189ea338
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1

--- a/outserv/Makefile
+++ b/outserv/Makefile
@@ -57,7 +57,7 @@ ifneq ($(strip $(BUILD_RACE)),)
 endif
 
 # jemalloc stuff
-HAS_JEMALLOC = $(shell test -f /usr/share/outserv/lib/libjemalloc.a && echo "jemalloc")
+HAS_JEMALLOC = $(shell test -f /usr/local/lib/libjemalloc_outcaste.a && echo "jemalloc")
 JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
 
 # nodejs
@@ -88,13 +88,13 @@ jemalloc:
 		curl -s -L ${JEMALLOC_URL} -o jemalloc.tar.bz2 ; \
 		tar xjf ./jemalloc.tar.bz2 ; \
 		cd jemalloc-5.2.1 ; \
-		./configure --prefix=/usr/share/outserv --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
+		./configure --with-install-suffix='_outcaste' --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
 		make ; \
 		if [ "$(USER_ID)" = "0" ]; then \
-			make install ; \
+			make install_lib install_include ; \
 		else \
 			echo "==== Need sudo access to install jemalloc" ; \
-			sudo make install ; \
+			sudo make install_lib install_include ; \
 		fi \
 	fi
 


### PR DESCRIPTION
Instead of installing jemalloc in `/usr/share`, this change brings it back to `/usr/local`, but adds an `_outcaste` suffix to the library names. This should help with installation on Mac (to be tested).

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/outserv/37)
<!-- Reviewable:end -->
