### PR TITLE
feat(ETH): Improve Eth3 importer

### DIFF
--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -293,11 +293,18 @@ func main() {
 
 	go printMetrics()
 
+	if *endBlock%Width != 0 || *startBlock%Width != 0 {
+		fmt.Printf("Both start and end must match width: %d\n", Width)
+		os.Exit(1)
+	}
 	th := y.NewThrottle(*numGo)
-	for i := *startBlock; i < *endBlock; {
+	for i := *endBlock; i > *startBlock; {
+		// for i := *startBlock; i < *endBlock; {
 		Check(th.Do())
-		go processAncients(th, db, i+1, i+Width)
-		i += Width
+		start, end := i-Width+1, i
+		fmt.Printf("Pushing start: %d end: %d\n", start, end)
+		go processAncients(th, db, start, end)
+		i -= Width
 	}
 	th.Finish()
 	fmt.Println("DONE")

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -91,7 +91,11 @@ func parseBody(dst *BlockOut, b *types.Body) {
 
 		txout := &TransactionOut{Transaction: txn.Transaction}
 		txout.From = &Account{Address: strings.ToLower(txn.From)}
+		txout.From.Uid = uid("Address", txout.From.Address)
+
 		txout.To = &Account{Address: strings.ToLower(txn.To)}
+		txout.To.Uid = uid("Address", txout.To.Address)
+
 		txout.Uid = uid("Transaction", txout.Hash)
 		dst.Transactions = append(dst.Transactions, txout)
 	}

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -156,10 +156,6 @@ func parseReceipts(out *BlockOut, rs []*types.ReceiptForStorage) {
 	}
 }
 
-func uid(typ, id string) string {
-	return fmt.Sprintf("_:%s.%s", typ, id)
-}
-
 // processAncients would output both start and end block.
 func processAncients(th *y.Throttle, db ethdb.Database, startBlock, endBlock uint64) {
 	defer th.Done(nil)
@@ -219,7 +215,12 @@ func processAncients(th *y.Throttle, db ethdb.Database, startBlock, endBlock uin
 			Check(rlp.DecodeBytes(val, &rs))
 			parseReceipts(block, rs)
 		}
-		data, err := json.Marshal([]*BlockOut{block}) // Use an array structure to make it work with chunker.
+
+		// We use an array to make it work with chunker. And we output one entry
+		// at a time, so jq can parse things easily, otherwise it chokes on the
+		// volume of the data. Ideally, we output a map at a time, no array.
+		// TODO(mrjn): Needs a bit of work for the chunker to parse those correctly.
+		data, err := json.Marshal([]*BlockOut{block})
 		Check(err)
 		oneWriter.Write(data)
 	}

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -216,7 +216,7 @@ func processAncients(th *y.Throttle, db ethdb.Database, startBlock, endBlock uin
 			Check(rlp.DecodeBytes(val, &rs))
 			parseReceipts(block, rs)
 		}
-		data, err := json.Marshal(block)
+		data, err := json.Marshal([]*BlockOut{block}) // Use an array structure to make it work with chunker.
 		Check(err)
 		oneWriter.Write(data)
 	}

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -151,7 +151,7 @@ func parseReceipts(out *BlockOut, rs []*types.ReceiptForStorage) {
 			log.LogIndex = hexutil.Uint(logIndex).String()
 			logIndex++
 			txn.Logs = append(txn.Logs, log)
-			out.Logs = append(out.Logs, Log{Lid: log.Lid}) // Just a ref is sufficient.
+			out.Logs = append(out.Logs, Log{Lid: log.Lid, Uid: log.Uid}) // Just a ref is sufficient.
 		}
 		out.Transactions = append(out.Transactions, txn)
 	}

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -103,6 +103,9 @@ func parseBody(dst *BlockOut, b *types.Body) {
 		Check(json.Unmarshal(data, &uin))
 		var uout BlockOut
 		uout.Block = uin.Block
+		if len(uin.Miner) > 0 {
+			uout.Miner = &Account{Address: uin.Miner}
+		}
 		dst.Ommers = append(dst.Ommers, uout)
 	}
 	dst.OmmerCount = hexutil.Uint(len(b.Uncles)).String()

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -303,7 +303,6 @@ func main() {
 	}
 	th := y.NewThrottle(*numGo)
 	for i := *endBlock; i > *startBlock; {
-		// for i := *startBlock; i < *endBlock; {
 		Check(th.Do())
 		start, end := i-Width+1, i
 		fmt.Printf("Pushing start: %d end: %d\n", start, end)

--- a/importers/eth3/main.go
+++ b/importers/eth3/main.go
@@ -91,12 +91,7 @@ func parseBody(dst *BlockOut, b *types.Body) {
 
 		txout := &TransactionOut{Transaction: txn.Transaction}
 		txout.From = &Account{Address: strings.ToLower(txn.From)}
-		txout.From.Uid = uid("Address", txout.From.Address)
-
 		txout.To = &Account{Address: strings.ToLower(txn.To)}
-		txout.To.Uid = uid("Address", txout.To.Address)
-
-		txout.Uid = uid("Transaction", txout.Hash)
 		dst.Transactions = append(dst.Transactions, txout)
 	}
 
@@ -108,7 +103,6 @@ func parseBody(dst *BlockOut, b *types.Body) {
 		Check(json.Unmarshal(data, &uin))
 		var uout BlockOut
 		uout.Block = uin.Block
-		uout.Uid = uid("Block", uin.Hash)
 		dst.Ommers = append(dst.Ommers, uout)
 	}
 	dst.OmmerCount = hexutil.Uint(len(b.Uncles)).String()
@@ -145,13 +139,12 @@ func parseReceipts(out *BlockOut, rs []*types.ReceiptForStorage) {
 			Check(json.Unmarshal(data, &log))
 
 			log.Lid = fmt.Sprintf("%s|%d", out.Hash, logIndex)
-			log.Uid = uid("Log", log.Lid)
 			log.BlockNumber = out.Number
 			log.TransactionIndex = hexutil.Uint(i).String()
 			log.LogIndex = hexutil.Uint(logIndex).String()
 			logIndex++
 			txn.Logs = append(txn.Logs, log)
-			out.Logs = append(out.Logs, Log{Lid: log.Lid, Uid: log.Uid}) // Just a ref is sufficient.
+			out.Logs = append(out.Logs, Log{Lid: log.Lid}) // Just a ref is sufficient.
 		}
 		out.Transactions = append(out.Transactions, txn)
 	}
@@ -202,10 +195,8 @@ func processAncients(th *y.Throttle, db ethdb.Database, startBlock, endBlock uin
 			var b BlockIn
 			Check(json.Unmarshal(data, &b))
 			block.Block = b.Block
-			block.Uid = uid("Block", b.Hash)
 			if len(b.Miner) > 0 {
 				block.Miner = &Account{
-					Uid:     uid("Address", b.Miner),
 					Address: b.Miner,
 				}
 			}

--- a/importers/eth3/types.go
+++ b/importers/eth3/types.go
@@ -1,7 +1,5 @@
 package main
 
-import "encoding/json"
-
 type Block struct {
 	Hash             string            `json:"hash,omitempty"`
 	Number           string            `json:"number,omitempty"`
@@ -23,8 +21,6 @@ type Block struct {
 	TransactionsRoot string            `json:"transactionsRoot,omitempty"`
 	Transactions     []*TransactionOut `json:"transactions,omitempty"`
 	Logs             []Log             `json:"logs,omitempty"`
-	Ommers           json.RawMessage   `json:"ommers,omitempty"`
-	OmmerCount       string            `json:"ommerCount,omitempty"`
 }
 
 type BlockIn struct {
@@ -34,8 +30,10 @@ type BlockIn struct {
 
 type BlockOut struct {
 	Block
-	Uid   string   `json:"uid,omitempty"`
-	Miner *Account `json:"miner,omitempty"`
+	Uid        string     `json:"uid,omitempty"`
+	Miner      *Account   `json:"miner,omitempty"`
+	Ommers     []BlockOut `json:"ommers,omitempty"`
+	OmmerCount string     `json:"ommerCount,omitempty"`
 }
 
 type Transaction struct {
@@ -72,6 +70,7 @@ type TransactionIn struct {
 }
 type TransactionOut struct {
 	Transaction
+	Uid  string   `json:"uid,omitempty"`
 	Fee  string   `json:"fee,omitempty"`
 	From *Account `json:"from,omitempty"`
 	To   *Account `json:"to,omitempty"`
@@ -91,6 +90,7 @@ type Log struct {
 	LogIndex         string   `json:"logIndex,omitempty"`
 	Removed          bool     `json:"removed,omitempty"`
 
+	Uid         string       `json:"uid,omitempty"`
 	Lid         string       `json:"lid,omitempty"`
 	Transaction *Transaction `json:"transaction,omitempty"`
 	Block       *Block       `json:"block,omitempty"`

--- a/importers/eth3/types.go
+++ b/importers/eth3/types.go
@@ -40,7 +40,8 @@ type BlockOut struct {
 
 func (b *BlockOut) MarshalJSON() ([]byte, error) {
 	b.Type = "Block"
-	return json.Marshal(b)
+	type Alias BlockOut
+	return json.Marshal(Alias(*b))
 }
 
 type Transaction struct {
@@ -85,7 +86,8 @@ type TransactionOut struct {
 
 func (t *TransactionOut) MarshalJSON() ([]byte, error) {
 	t.Type = "Transaction"
-	return json.Marshal(t)
+	type Alias TransactionOut
+	return json.Marshal(Alias(*t))
 }
 
 type Account struct {
@@ -96,7 +98,8 @@ type Account struct {
 func (a *Account) MarshalJSON() ([]byte, error) {
 	// type Alias BlockOut
 	a.Type = "Account"
-	return json.Marshal(a)
+	type Alias Account
+	return json.Marshal(Alias(*a))
 }
 
 type Log struct {
@@ -116,5 +119,6 @@ type Log struct {
 
 func (l *Log) MarshalJSON() ([]byte, error) {
 	l.Type = "Log"
-	return json.Marshal(l)
+	type Alias Log
+	return json.Marshal(Alias(*l))
 }

--- a/importers/eth3/types.go
+++ b/importers/eth3/types.go
@@ -1,5 +1,7 @@
 package main
 
+import "encoding/json"
+
 type Block struct {
 	Hash             string            `json:"hash,omitempty"`
 	Number           string            `json:"number,omitempty"`
@@ -30,10 +32,15 @@ type BlockIn struct {
 
 type BlockOut struct {
 	Block
-	Uid        string     `json:"uid,omitempty"`
+	Type       string     `json:"@type,omitempty"`
 	Miner      *Account   `json:"miner,omitempty"`
 	Ommers     []BlockOut `json:"ommers,omitempty"`
 	OmmerCount string     `json:"ommerCount,omitempty"`
+}
+
+func (b *BlockOut) MarshalJSON() ([]byte, error) {
+	b.Type = "Block"
+	return json.Marshal(b)
 }
 
 type Transaction struct {
@@ -70,15 +77,26 @@ type TransactionIn struct {
 }
 type TransactionOut struct {
 	Transaction
-	Uid  string   `json:"uid,omitempty"`
+	Type string   `json:"@type,omitempty"`
 	Fee  string   `json:"fee,omitempty"`
 	From *Account `json:"from,omitempty"`
 	To   *Account `json:"to,omitempty"`
 }
 
+func (t *TransactionOut) MarshalJSON() ([]byte, error) {
+	t.Type = "Transaction"
+	return json.Marshal(t)
+}
+
 type Account struct {
-	Uid     string `json:"uid,omitempty"`
+	Type    string `json:"@type"`
 	Address string `json:"address,omitempty"`
+}
+
+func (a *Account) MarshalJSON() ([]byte, error) {
+	// type Alias BlockOut
+	a.Type = "Account"
+	return json.Marshal(a)
 }
 
 type Log struct {
@@ -90,8 +108,13 @@ type Log struct {
 	LogIndex         string   `json:"logIndex,omitempty"`
 	Removed          bool     `json:"removed,omitempty"`
 
-	Uid         string       `json:"uid,omitempty"`
+	Type        string       `json:"@type,omitempty"`
 	Lid         string       `json:"lid,omitempty"`
 	Transaction *Transaction `json:"transaction,omitempty"`
 	Block       *Block       `json:"block,omitempty"`
+}
+
+func (l *Log) MarshalJSON() ([]byte, error) {
+	l.Type = "Log"
+	return json.Marshal(l)
 }


### PR DESCRIPTION
- Add `@type` field to the maps, so we can know what type they are.
- Handle the `miner` field in ommers, before it was being stored as a string, instead of as a map.
- Set the width to 10000, and start downloading blocks from back -> front.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/outserv/79)
<!-- Reviewable:end -->
