### PR TITLE
feat(Boot): Use type information in boot loader

### DIFF
--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -46,9 +46,9 @@ func (jc *Chunker) NQuads() *NQuadBuffer {
 }
 
 // NewChunker returns a new chunker for the specified format.
-func NewChunker(batchSize int) *Chunker {
+func NewChunker(schema *gqlSchema.Schema, batchSize int) *Chunker {
 	return &Chunker{
-		nqs: NewNQuadBuffer(batchSize),
+		nqs: NewNQuadBuffer(schema, batchSize),
 	}
 }
 

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -29,6 +29,7 @@ import (
 	"unicode"
 
 	"github.com/outcaste-io/outserv/ee/enc"
+	gqlSchema "github.com/outcaste-io/outserv/graphql/schema"
 	"github.com/outcaste-io/outserv/x"
 
 	"github.com/pkg/errors"
@@ -200,11 +201,11 @@ func (*Chunker) nextRune(r *bufio.Reader) (rune, error) {
 	return ch, nil
 }
 
-func (jc *Chunker) Parse(chunkBuf *bytes.Buffer) error {
+func (jc *Chunker) Parse(chunkBuf *bytes.Buffer, typ *gqlSchema.Type) error {
 	if chunkBuf == nil || chunkBuf.Len() == 0 {
 		return nil
 	}
-	return jc.nqs.FastParseJSON(chunkBuf.Bytes(), SetNquads)
+	return jc.nqs.FastParseJSON(chunkBuf.Bytes(), typ, SetNquads)
 }
 
 func slurpSpace(r *bufio.Reader) error {

--- a/chunker/json.go
+++ b/chunker/json.go
@@ -256,9 +256,6 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, typ *gqlSchema.Typ
 	x.AssertTrue(typ != nil)
 	var mr mapResponse
 
-	// Find the type of the object, and the corresponding ID field. And use that
-	// for determining the UID.
-	//
 	// Check field in map.
 	if uidVal, ok := m["uid"]; ok {
 		var uid uint64
@@ -293,6 +290,9 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, typ *gqlSchema.Typ
 			mr.uid = x.ToHexString(uid)
 		}
 	}
+
+	// Use the type of the object and the corresponding XID fields to
+	// determine the UID.
 	if mr.uid == "" {
 		var comp []string
 		for _, fd := range typ.XIDFields() {
@@ -302,7 +302,6 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, typ *gqlSchema.Typ
 			}
 		}
 		mr.uid = fmt.Sprintf("_:%s.%s", typ.Name(), strings.Join(comp, "|"))
-		// fmt.Printf("Assigned UID to %s -> %s\n", typ.Name(), mr.uid)
 	}
 
 	if mr.uid == "" {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1574,7 +1574,7 @@ func parseMutationObject(mu *pb.Mutation, qc *queryContext) (*pb.Mutation, error
 	res := &pb.Mutation{Cond: mu.Cond}
 
 	if len(mu.SetJson) > 0 {
-		nqs, err := chunker.ParseJSON(mu.SetJson, chunker.SetNquads)
+		nqs, err := chunker.ParseJSON(mu.SetJson, qc.gqlField.Type(), chunker.SetNquads)
 		if err != nil {
 			return nil, err
 		}
@@ -1582,7 +1582,7 @@ func parseMutationObject(mu *pb.Mutation, qc *queryContext) (*pb.Mutation, error
 	}
 	if len(mu.DeleteJson) > 0 {
 		// The metadata is not currently needed for delete operations so it can be safely ignored.
-		nqs, err := chunker.ParseJSON(mu.DeleteJson, chunker.DeleteNquads)
+		nqs, err := chunker.ParseJSON(mu.DeleteJson, qc.gqlField.Type(), chunker.DeleteNquads)
 		if err != nil {
 			return nil, err
 		}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -357,6 +357,7 @@ func dgraphMapping(sch *ast.Schema) map[string]map[string]string {
 		payload = "Payload"
 	)
 
+	// TODO(mrjn): Remove this dgraphPredicate stuff.
 	dgraphPredicate := make(map[string]map[string]string)
 	for _, inputTyp := range sch.Types {
 		// We only want to consider input types (object and interface) defined by the user as part

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -93,15 +93,6 @@ const (
 	FilterArgName                     = "filter"
 )
 
-// A Type is a GraphQL type like: Float, T, T! and [T!]!.  If it's not a list, then
-// ListType is nil.  If it's an object type then Field gets field definitions by
-// name from the definition of the type; IDField gets the ID field of the type.
-type Type struct {
-	typ             *ast.Type
-	inSchema        *Schema
-	dgraphPredicate map[string]map[string]string
-}
-
 type Schema struct {
 	schema *ast.Schema
 	// dgraphPredicate gives us the dgraph predicate corresponding to a typeName + fieldName.
@@ -1540,12 +1531,19 @@ func mutationType(name string, custom *ast.Directive) MutationType {
 	}
 }
 
-func (t *Type) IsGeo() bool {
-	return t.Name() == "Point" || t.Name() == "Polygon" || t.Name() == "MultiPolygon"
+// A Type is a GraphQL type like: Float, T, T! and [T!]!.  If it's not a list, then
+// ListType is nil.  If it's an object type then Field gets field definitions by
+// name from the definition of the type; IDField gets the ID field of the type.
+type Type struct {
+	typ             *ast.Type
+	inSchema        *Schema
+	dgraphPredicate map[string]map[string]string
 }
 
-func (t *Type) IsAggregateResult() bool {
-	return strings.HasSuffix(t.Name(), "AggregateResult")
+func (t *Type) Schema() *Schema         { return t.inSchema }
+func (t *Type) IsAggregateResult() bool { return strings.HasSuffix(t.Name(), "AggregateResult") }
+func (t *Type) IsGeo() bool {
+	return t.Name() == "Point" || t.Name() == "Polygon" || t.Name() == "MultiPolygon"
 }
 
 func (t *Type) Field(name string) *FieldDefinition {

--- a/importers/eth3/schema.graphql
+++ b/importers/eth3/schema.graphql
@@ -1,0 +1,80 @@
+type Block {
+  hash: String! @id
+
+  number: Int64 @search
+  baseFeePerGas: BigInt
+  difficulty: BigInt
+  extraData: String
+  gasLimit: Int64 @search
+  gasUsed: Int64 @search
+  logsBloom: String
+  miner: Account
+  mixHash: String
+  nonce: String
+  parentHash: String
+  receiptsRoot: String
+  sha3Uncles: String
+  size: Int64 @search
+  stateRoot: String
+  timestamp: DateTime @search(by: [day])
+  totalDifficulty: BigInt
+  transactions: [Transaction]
+  transactionsRoot: String
+  ommers: [Block]
+  ommerCount: Int64
+  logs: [Log]
+}
+
+type Account {
+  address: String! @id
+
+  incoming: [Transaction] @hasInverse(field: to)
+  outgoing: [Transaction] @hasInverse(field: from)
+  mined: [Block] @hasInverse(field: miner)
+}
+
+type Transaction {
+  hash: String @id
+
+  block: Block @hasInverse(field: transactions)
+  blockNumber: Int64 @search
+  from: Account
+  gas: Int64 @search
+  gasPrice: BigInt
+  maxFeePerGas: BigInt
+  maxPriorityFeePerGas: BigInt
+  input: String
+  nonce: Int64
+  to: Account
+  transactionIndex: Int64
+  value: BigInt @search
+  fee: BigInt @search
+  type: Int64
+  # accessList -- ignore for now
+  chainId: Int64
+  v: String
+  r: String
+  s: String
+  logsBloom: String
+
+  # Fields picked from receipt
+  root: String
+  contractAddress: String @search
+  cumulativeGasUsed: Int64 @search
+  gasUsed: Int64 @search
+  status: Int64
+  logs: [Log]
+}
+
+type Log {
+  lid: String @id
+  address: String @search(by: [exact])
+  topics: [String] @search(by: [exact])
+  data: String
+  blockNumber: Int64 @search
+  transactionIndex: Int64
+  logIndex: Int64
+  removed: Boolean
+  transaction: Transaction @hasInverse(field: logs)
+  block: Block @hasInverse(field: logs)
+}

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -218,6 +218,7 @@ func (m *mapper) run() {
 
 	for nqs := range nquads.Ch() {
 		for _, nq := range nqs {
+			// fmt.Printf("got nq: %+v\n", nq)
 			m.processNQuad(nq)
 			atomic.AddInt64(&m.prog.nquadCount, 1)
 		}
@@ -366,7 +367,7 @@ func (m *mapper) createPostings(nq *pb.Edge) *pb.Posting {
 	sch := m.dqlSchema.getSchema(nq.Predicate)
 	if sch == nil {
 		fmt.Printf("schema: %+v\n", m.dqlSchema.schemaMap)
-		fmt.Printf("asking for: %q\n", nq.Predicate)
+		fmt.Printf("asking for: %q in nq: %+v\n", nq.Predicate, nq)
 		x.AssertTrue(sch != nil)
 	}
 	if nq.GetObjectValue() != nil {
@@ -395,7 +396,10 @@ func (m *mapper) addIndexMapEntries(nq *pb.Edge) {
 
 	toType := types.TypeID(sch.GetValueType())
 	tokens, err := posting.TokensFromVal(tokenizers, toType, nq.ObjectValue)
-	x.Check(err)
+	if err != nil {
+		fmt.Printf("Got error: %v from nq: %+v\n", err, nq)
+		x.Check(err)
+	}
 
 	// Store index posting.
 	uid := x.FromHex(nq.Subject)

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -218,7 +218,6 @@ func (m *mapper) run() {
 
 	for nqs := range nquads.Ch() {
 		for _, nq := range nqs {
-			// fmt.Printf("got nq: %+v\n", nq)
 			m.processNQuad(nq)
 			atomic.AddInt64(&m.prog.nquadCount, 1)
 		}

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -201,11 +201,12 @@ func (m *mapper) writeMapEntriesToFile(cbuf *z.Buffer, shardIdx int) {
 var once sync.Once
 
 func (m *mapper) run() {
+	typ := m.gqlSchema.Type(m.opt.GqlType)
 	chunk := chunker.NewChunker(1000)
 	nquads := chunk.NQuads()
 	go func() {
 		for chunkBuf := range m.readerChunkCh {
-			if err := chunk.Parse(chunkBuf); err != nil {
+			if err := chunk.Parse(chunkBuf, typ); err != nil {
 				atomic.AddInt64(&m.prog.errCount, 1)
 				if !m.opt.IgnoreErrors {
 					x.Check(err)

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -202,7 +202,7 @@ var once sync.Once
 
 func (m *mapper) run() {
 	typ := m.gqlSchema.Type(m.opt.GqlType)
-	chunk := chunker.NewChunker(1000)
+	chunk := chunker.NewChunker(m.gqlSchema, 1000)
 	nquads := chunk.NQuads()
 	go func() {
 		for chunkBuf := range m.readerChunkCh {

--- a/outserv/cmd/boot/run.go
+++ b/outserv/cmd/boot/run.go
@@ -64,7 +64,8 @@ func init() {
 	flag.StringP("files", "f", "",
 		"Location of *.json(.gz) file(s) to load.")
 	flag.StringP("schema", "s", "", "Location of the GraphQL schema file.")
-	flag.StringP("type", "t", "", "GraphQL type of the root object in file")
+	flag.StringP("type", "t", "", "GraphQL type of the root object in file."+
+		" Useful if no @type field is present in the JSON objects.")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -460,7 +461,7 @@ func (ld *loader) blockingFileReader() {
 			r, cleanup := fs.ChunkReader(file, nil)
 			defer cleanup()
 
-			chunk := chunker.NewChunker(1000)
+			chunk := chunker.NewChunker(ld.gqlSchema, 1000)
 			for {
 				chunkBuf, err := chunk.Chunk(r)
 				if chunkBuf != nil && chunkBuf.Len() > 0 {
@@ -496,7 +497,7 @@ func (ld *loader) blockingIPCReader() {
 			defer fd.Close()
 
 			r := bufio.NewReaderSize(fd, 32<<20)
-			chunk := chunker.NewChunker(1000)
+			chunk := chunker.NewChunker(ld.gqlSchema, 1000)
 			for {
 				chunkBuf, err := chunk.Chunk(r)
 				if chunkBuf != nil && chunkBuf.Len() > 0 {

--- a/outserv/cmd/boot/run.go
+++ b/outserv/cmd/boot/run.go
@@ -64,6 +64,7 @@ func init() {
 	flag.StringP("files", "f", "",
 		"Location of *.json(.gz) file(s) to load.")
 	flag.StringP("schema", "s", "", "Location of the GraphQL schema file.")
+	flag.StringP("type", "t", "", "GraphQL type of the root object in file")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -133,6 +134,7 @@ func run() {
 		DataIPC:          Boot.Conf.GetString("ipc"),
 		EncryptionKey:    keys.EncKey,
 		GqlSchemaFile:    Boot.Conf.GetString("schema"),
+		GqlType:          Boot.Conf.GetString("type"),
 		OutDir:           Boot.Conf.GetString("out"),
 		ReplaceOutDir:    Boot.Conf.GetBool("replace_out"),
 		TmpDir:           Boot.Conf.GetString("tmp"),
@@ -331,6 +333,7 @@ type options struct {
 	DataFiles        string
 	DataIPC          string
 	GqlSchemaFile    string
+	GqlType          string
 	OutDir           string
 	ReplaceOutDir    bool
 	TmpDir           string

--- a/outserv/cmd/boot/run.go
+++ b/outserv/cmd/boot/run.go
@@ -74,7 +74,7 @@ func init() {
 		"Temp directory used to use for on-disk scratch space. Requires free space proportional"+
 			" to the size of the RDF file and the amount of indexing used.")
 
-	flag.IntP("num_go_routines", "j", int(math.Ceil(float64(runtime.NumCPU())/4.0)),
+	flag.IntP("num_go_routines", "j", int(math.Ceil(float64(runtime.NumCPU())*0.85)),
 		"Number of worker threads to use. MORE THREADS LEAD TO HIGHER RAM USAGE.")
 	flag.Int64("mapoutput_mb", 2048,
 		"The estimated size of each map file output. Increasing this increases memory usage.")


### PR DESCRIPTION
The type information can be generated by either passing in the type of the root object as a flag or by having a `@type` field in the objects. Once a type for the parent object is determined, the children object types are deduced from the GraphQL Schema.

All this info is used to generate UIDs for the objects if none is provided.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/outserv/80)
<!-- Reviewable:end -->
