### PR TITLE
feat(boot): Add BufReader and switch back to Snappy

### DIFF
--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -38,11 +38,14 @@ type shardState struct {
 	mu   sync.Mutex // Allow only 1 write per shard at a time.
 }
 
+var mapBuf int64
+
 func newMapperBuffer(opt *options) *z.Buffer {
 	sz := float64(opt.MapBufSize) * 1.1
 	// We don't have a lot of map shards. So, we can just store all this in
 	// memory, instead of writing to a file on disk.
-	buf := z.NewBuffer(int(sz), "map.buffer")
+	id := atomic.AddInt64(&mapBuf, 1)
+	buf := z.NewBuffer(int(sz), fmt.Sprintf("map.buffer-%02d", id/4))
 	return buf.WithMaxSize(2 * int(opt.MapBufSize))
 }
 

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/klauspost/compress/zstd"
+	"github.com/golang/snappy"
 	"github.com/outcaste-io/outserv/chunker"
 	"github.com/outcaste-io/outserv/posting"
 	"github.com/outcaste-io/outserv/protos/pb"
@@ -157,7 +157,7 @@ func (m *mapper) writeMapEntriesToFile(cbuf *z.Buffer, shardIdx int) {
 	// operations needed.
 	var buf bytes.Buffer
 	buf.Grow(int(m.opt.MapBufSize / 8))
-	w, err := zstd.NewWriter(&buf)
+	w := snappy.NewWriter(&buf)
 	x.Check(err)
 	defer func() {
 		x.Check(w.Close())

--- a/outserv/cmd/boot/mapper.go
+++ b/outserv/cmd/boot/mapper.go
@@ -123,7 +123,7 @@ func (m *mapper) openOutputFile(shardIdx int) (*os.File, error) {
 		m.opt.MapDir,
 		mapShardDir,
 		fmt.Sprintf("%03d", shardIdx),
-		fmt.Sprintf("%06d.map.gz", fileNum),
+		fmt.Sprintf("%06d.map", fileNum),
 	)
 	x.Check(os.MkdirAll(filepath.Dir(filename), 0750))
 	return os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)

--- a/outserv/cmd/boot/merge_shards.go
+++ b/outserv/cmd/boot/merge_shards.go
@@ -63,7 +63,6 @@ func mergeMapShardsIntoReduceShards(opt *options) {
 
 func readShardDirs(d string) []string {
 	_, err := os.Stat(d)
-	fmt.Printf("d: %s | error: %v\n", d, err)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -76,7 +75,6 @@ func readShardDirs(d string) []string {
 		shards[i] = filepath.Join(d, shard)
 	}
 	sort.Strings(shards)
-	fmt.Printf("shards: %+v\n", shards)
 	return shards
 }
 

--- a/outserv/cmd/boot/merge_shards.go
+++ b/outserv/cmd/boot/merge_shards.go
@@ -76,6 +76,7 @@ func readShardDirs(d string) []string {
 		shards[i] = filepath.Join(d, shard)
 	}
 	sort.Strings(shards)
+	fmt.Printf("shards: %+v\n", shards)
 	return shards
 }
 
@@ -85,7 +86,7 @@ func filenamesInTree(dir string) []string {
 		if err != nil {
 			return err
 		}
-		if strings.HasSuffix(path, ".gz") {
+		if strings.HasSuffix(path, ".map") {
 			fnames = append(fnames, path)
 		}
 		return nil

--- a/outserv/cmd/boot/merge_shards.go
+++ b/outserv/cmd/boot/merge_shards.go
@@ -63,6 +63,7 @@ func mergeMapShardsIntoReduceShards(opt *options) {
 
 func readShardDirs(d string) []string {
 	_, err := os.Stat(d)
+	fmt.Printf("d: %s | error: %v\n", d, err)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -510,12 +510,16 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 				fmt.Printf("[%d] SKIPPING %d keys\n", i, len(fps))
 				dst := getBuf(r.opt.BufDir)
 				var skipCount, skipBytes uint64
+				printed := make(map[uint64]bool)
 				err := cbuf.SliceIterate(func(slice []byte) error {
 					me := MapEntry(slice)
 					fp := z.MemHash(me.Key())
-					if _, has := fps[fp]; !has {
+					if cnt, has := fps[fp]; !has {
 						dst.WriteSlice(slice)
 					} else {
+						if _, did := printed[fp]; !did {
+							fmt.Printf("SKIPPING KEY: %x . Count: %d\n", me.Key(), cnt)
+						}
 						skipCount++
 						skipBytes += uint64(len(slice))
 					}

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -153,7 +153,7 @@ func (r *reducer) createTmpBadger() *badger.DB {
 
 type mapIterator struct {
 	fd     *os.File
-	reader *snappy.Reader
+	reader *x.BufReader
 	meBuf  []byte
 }
 
@@ -221,10 +221,10 @@ func newMapIterator(filename string) (*pb.MapHeader, *mapIterator) {
 
 	// TODO: Release dec in the end.
 	// dec := zstd.NewReader(fd)
-	// reader := x.NewBufReader(dec, 512<<10)
 	// dec, err := zstd.NewReader(fd, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
 	// x.Check(err)
-	reader := snappy.NewReader(fd)
+	r := snappy.NewReader(fd)
+	reader := x.NewBufReader(r, 1<<20)
 
 	// Read the header size.
 	headerLenBuf := make([]byte, 4)

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -489,18 +489,18 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		partitionKeys = append(partitionKeys, nil)
 		fmt.Printf("Num Partitions: %d\n", len(partitionKeys))
 
+		keyCount := make(map[uint64]uint64)
 		for i := 0; i < len(partitionKeys); i++ {
 			pkey := partitionKeys[i]
 
-			keyCount := make(map[uint64]uint64)
 			for _, itr := range mapItrs {
 				itr.Next(cbuf, pkey, keyCount)
-				for key, cnt := range keyCount {
-					if cnt < 1000 {
-						// Remove small keys.
-						delete(keyCount, key)
-					}
-				}
+				// for key, cnt := range keyCount {
+				// 	if cnt < 1000 {
+				// 		// Remove small keys.
+				// 		delete(keyCount, key)
+				// 	}
+				// }
 			}
 			if len(keyCount) > 0 {
 				fmt.Printf("[%d] keyCount size: %d\n", i, len(keyCount))
@@ -512,7 +512,9 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 					fps[key] = cnt
 					fmt.Printf("[%d] SKIP key: %x with count: %d\n", i, key, cnt)
 				}
+				delete(keyCount, key) // Empty it out for future use.
 			}
+			x.AssertTrue(len(keyCount) == 0)
 			if len(fps) > 0 {
 				fmt.Printf("[%d] SKIPPING %d keys\n", i, len(fps))
 				dst := getBuf(r.opt.BufDir)

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -552,8 +552,6 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 			}
 
 			buffers <- cbuf
-			fmt.Printf("[%d] len(buffers): %d\n", i, len(buffers))
-			// cbuf.Reset()
 			cbuf = getBuf(r.opt.BufDir)
 		}
 		if !cbuf.IsEmpty() {

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -449,8 +449,56 @@ func bufferStats(cbuf *z.Buffer) {
 
 func getBuf(dir string) *z.Buffer {
 	return z.NewBuffer(64<<20, "Reducer.GetBuf").
-		WithAutoMmap(1<<30, dir).
+		WithAutoMmap(4<<30, dir).
 		WithMaxSize(128 << 30)
+}
+
+type BufReq struct {
+	sync.WaitGroup
+	cbuf     *z.Buffer
+	keyCount map[uint64]uint64
+	bufDir   string
+}
+
+func (breq *BufReq) Trim() {
+	defer breq.Done()
+
+	fps := make(map[uint64]uint64)
+	for key, cnt := range breq.keyCount {
+		if cnt >= 1e6 {
+			fps[key] = cnt
+			fmt.Printf("SKIP key: %x with count: %d\n", key, cnt)
+		}
+	}
+	if len(fps) == 0 {
+		return
+	}
+	fmt.Printf("SKIPPING %d keys\n", len(fps))
+
+	var skipCount, skipBytes uint64
+	printed := make(map[uint64]bool)
+	dst := getBuf(breq.bufDir)
+
+	err := breq.cbuf.SliceIterate(func(slice []byte) error {
+		me := MapEntry(slice)
+		fp := z.MemHash(me.Key())
+		if cnt, has := fps[fp]; !has {
+			dst.WriteSlice(slice)
+		} else {
+			skipCount++
+			skipBytes += uint64(len(slice))
+			if _, did := printed[fp]; !did {
+				fmt.Printf("SKIPPING KEY: %x . Count: %d\n", me.Key(), cnt)
+				printed[fp] = true
+			}
+		}
+		return nil
+	})
+	x.Check(err)
+	fmt.Printf("Skipped over %d keys | data: %s\n",
+		skipCount, humanize.IBytes(skipBytes))
+	breq.cbuf.Release()
+	breq.cbuf = dst
 }
 
 func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *countIndexer) {
@@ -482,90 +530,60 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		writerCh <- req
 	}
 
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	buffers := make(chan *z.Buffer, 3)
+	buffers := make(chan *BufReq, 8)
 
 	go func() {
 		// Start collecting buffers.
-		hd := z.NewHistogramData(z.HistogramBounds(16, 40))
 		cbuf := getBuf(r.opt.BufDir)
+		keyCount := make(map[uint64]uint64)
+
 		// Append nil for the last entries.
 		partitionKeys = append(partitionKeys, nil)
 		fmt.Printf("Num Partitions: %d\n", len(partitionKeys))
 
-		keyCount := make(map[uint64]uint64)
 		for i := 0; i < len(partitionKeys); i++ {
 			pkey := partitionKeys[i]
 
 			for _, itr := range mapItrs {
 				itr.Next(cbuf, pkey, keyCount)
 			}
-
-			fps := make(map[uint64]uint64)
-			for key, cnt := range keyCount {
-				if cnt >= 1e6 {
-					fps[key] = cnt
-					fmt.Printf("[%d] SKIP key: %x with count: %d\n", i, key, cnt)
-				}
-				delete(keyCount, key) // Empty it out for future use.
-			}
-			x.AssertTrue(len(keyCount) == 0)
-			if len(fps) > 0 {
-				fmt.Printf("[%d] SKIPPING %d keys\n", i, len(fps))
-				dst := getBuf(r.opt.BufDir)
-				var skipCount, skipBytes uint64
-				printed := make(map[uint64]bool)
-				err := cbuf.SliceIterate(func(slice []byte) error {
-					me := MapEntry(slice)
-					fp := z.MemHash(me.Key())
-					if cnt, has := fps[fp]; !has {
-						dst.WriteSlice(slice)
-					} else {
-						skipCount++
-						skipBytes += uint64(len(slice))
-						if _, did := printed[fp]; !did {
-							fmt.Printf("SKIPPING KEY: %x . Count: %d\n", me.Key(), cnt)
-							printed[fp] = true
-						}
-					}
-					return nil
-				})
-				x.Check(err)
-				fmt.Printf("[%d] Skipped over %d keys | data: %s\n",
-					i, skipCount, humanize.IBytes(skipBytes))
-				cbuf.Release()
-				cbuf = dst
-			}
-			if cbuf.LenNoPadding() < 256<<20 {
+			if i < len(partitionKeys)-1 && cbuf.LenNoPadding() < 1<<30 {
+				// Don't enter this if for penultimate loop.
 				// Pick up more data.
 				continue
 			}
 
-			hd.Update(int64(cbuf.LenNoPadding()))
-			select {
-			case <-ticker.C:
-				fmt.Printf("[%d] Histogram of buffer sizes: %s\n", i, hd.String())
-			default:
+			breq := &BufReq{
+				cbuf:     cbuf,
+				keyCount: keyCount,
+				bufDir:   r.opt.BufDir,
 			}
+			breq.Add(1)
+			go breq.Trim()
+			buffers <- breq
 
-			buffers <- cbuf
-			fmt.Printf("[%d] len(buffers): %d\n", i, len(buffers))
-			// cbuf.Reset()
+			// Prepare for next.
+			keyCount = make(map[uint64]uint64)
 			cbuf = getBuf(r.opt.BufDir)
 		}
-		if !cbuf.IsEmpty() {
-			hd.Update(int64(cbuf.LenNoPadding()))
-			buffers <- cbuf
-		} else {
-			cbuf.Release()
-		}
-		fmt.Printf("Final Histogram of buffer sizes: %s\n", hd.String())
+		x.AssertTrue(cbuf.IsEmpty())
+		cbuf.Release()
 		close(buffers)
 	}()
 
-	for cbuf := range buffers {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	hd := z.NewHistogramData(z.HistogramBounds(16, 40))
+	for breq := range buffers {
+		breq.Wait()
+		cbuf := breq.cbuf
+		hd.Update(int64(cbuf.LenNoPadding()))
+		select {
+		case <-ticker.C:
+			fmt.Printf("Histogram of buffer sizes: %s\n", hd.String())
+		default:
+		}
 		if cbuf.LenNoPadding() > limit/2 {
 			bufferStats(cbuf)
 		}
@@ -574,6 +592,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		atomic.AddInt64(&r.prog.numEncoding, int64(cbuf.LenNoPadding()))
 		sendReq(cbuf)
 	}
+	fmt.Printf("Final Histogram of buffer sizes: %s\n", hd.String())
 
 	// Close the encodes.
 	close(encoderCh)

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -495,15 +495,6 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 
 			for _, itr := range mapItrs {
 				itr.Next(cbuf, pkey, keyCount)
-				// for key, cnt := range keyCount {
-				// 	if cnt < 1000 {
-				// 		// Remove small keys.
-				// 		delete(keyCount, key)
-				// 	}
-				// }
-			}
-			if len(keyCount) > 0 {
-				fmt.Printf("[%d] keyCount size: %d\n", i, len(keyCount))
 			}
 
 			fps := make(map[uint64]uint64)

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -209,6 +209,7 @@ func (mi *mapIterator) Next(cbuf *z.Buffer, partitionKey []byte, keyCount map[ui
 }
 
 func (mi *mapIterator) Close() error {
+	mi.reader.Close()
 	return mi.fd.Close()
 }
 

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -219,7 +219,7 @@ func newMapIterator(filename string) (*pb.MapHeader, *mapIterator) {
 
 	// TODO: Release dec in the end.
 	dec := zstd.NewReader(fd)
-	reader := x.NewBufReader(dec, 1<<20)
+	reader := x.NewBufReader(dec, 512<<10)
 	// dec, err := zstd.NewReader(fd, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
 	// x.Check(err)
 	// r := snappy.NewReader(fd)
@@ -403,7 +403,8 @@ func (r *reducer) writeSplitLists(db, tmpDb *badger.DB, writer *badger.StreamWri
 	x.Check(stream.Orchestrate(context.Background()))
 }
 
-const limit = 32 << 30
+// 2 GB is good. Don't increase it.
+const limit = 2 << 30
 
 var tcounter int64
 

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -46,7 +46,6 @@ type reducer struct {
 
 func (r *reducer) run() error {
 	dirs := readShardDirs(filepath.Join(r.opt.MapDir, reduceShardDir))
-	fmt.Printf("dirs: %+v\n", dirs)
 	x.AssertTrue(len(dirs) == r.opt.ReduceShards)
 	x.AssertTrue(len(r.opt.shardOutputDirs) == r.opt.ReduceShards)
 
@@ -58,9 +57,7 @@ func (r *reducer) run() error {
 		go func(shardId int, db *badger.DB, tmpDb *badger.DB) {
 			defer thr.Done(nil)
 
-			fmt.Printf("tree: %s\n", dirs[shardId])
 			mapFiles := filenamesInTree(dirs[shardId])
-			fmt.Printf("num map files: %d\n", len(mapFiles))
 			var mapItrs []*mapIterator
 
 			// Dedup the partition keys.
@@ -219,10 +216,6 @@ func newMapIterator(filename string) (*pb.MapHeader, *mapIterator) {
 	fd, err := os.Open(filename)
 	x.Check(err)
 
-	// TODO: Release dec in the end.
-	// dec := zstd.NewReader(fd)
-	// dec, err := zstd.NewReader(fd, zstd.WithDecoderConcurrency(1), zstd.WithDecoderLowmem(true))
-	// x.Check(err)
 	r := snappy.NewReader(fd)
 	reader := x.NewBufReader(r, 1<<20)
 

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -46,6 +46,7 @@ type reducer struct {
 
 func (r *reducer) run() error {
 	dirs := readShardDirs(filepath.Join(r.opt.MapDir, reduceShardDir))
+	fmt.Printf("dirs: %+v\n", dirs)
 	x.AssertTrue(len(dirs) == r.opt.ReduceShards)
 	x.AssertTrue(len(r.opt.shardOutputDirs) == r.opt.ReduceShards)
 
@@ -57,7 +58,9 @@ func (r *reducer) run() error {
 		go func(shardId int, db *badger.DB, tmpDb *badger.DB) {
 			defer thr.Done(nil)
 
+			fmt.Printf("tree: %s\n", dirs[shardId])
 			mapFiles := filenamesInTree(dirs[shardId])
+			fmt.Printf("num map files: %d\n", len(mapFiles))
 			var mapItrs []*mapIterator
 
 			// Dedup the partition keys.

--- a/outserv/cmd/boot/reduce.go
+++ b/outserv/cmd/boot/reduce.go
@@ -420,7 +420,7 @@ func (r *reducer) throttle() {
 		if sz < limit {
 			return
 		}
-		for i%10 == 0 {
+		if i%10 == 0 {
 			fmt.Printf("[%x] [%d] Throttling sz: %d\n", num, i, sz)
 		}
 		time.Sleep(time.Second)
@@ -530,7 +530,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		writerCh <- req
 	}
 
-	buffers := make(chan *BufReq, 8)
+	buffers := make(chan *BufReq, 4)
 
 	go func() {
 		// Start collecting buffers.

--- a/outserv/cmd/boot/run.go
+++ b/outserv/cmd/boot/run.go
@@ -78,9 +78,9 @@ func init() {
 
 	flag.IntP("num_go_routines", "j", int(math.Ceil(float64(runtime.NumCPU())*0.85)),
 		"Number of worker threads to use. MORE THREADS LEAD TO HIGHER RAM USAGE.")
-	flag.Int64("mapoutput_mb", 4096,
+	flag.Int64("mapoutput_mb", 2048, // We need to stick to 2GB to use 32 concurrent processes.
 		"The estimated size of each map file output. Increasing this increases memory usage.")
-	flag.Int64("partition_mb", 8, "Pick a partition key every N megabytes of data.")
+	flag.Int64("partition_mb", 32, "Pick a partition key every N megabytes of data.")
 	flag.Bool("skip_map_phase", false,
 		"Skip the map phase (assumes that map output files already exist).")
 	flag.Bool("cleanup_map", false,

--- a/outserv/cmd/debug/run.go
+++ b/outserv/cmd/debug/run.go
@@ -636,12 +636,12 @@ func testZstdDecompress() {
 	buf := make([]byte, 64<<20)
 
 	for {
-		_, err := br.Read(buf)
+		n, err := br.Read(buf[:cap(buf)])
 		if err == io.EOF {
 			return
 		}
 		x.Check(err)
-		_, err = os.Stdout.Write(buf)
+		_, err = os.Stdout.Write(buf[:n])
 		x.Check(err)
 	}
 }

--- a/outserv/cmd/debug/run.go
+++ b/outserv/cmd/debug/run.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/zstd"
 	"github.com/dustin/go-humanize"
+	"github.com/golang/snappy"
 	"github.com/outcaste-io/outserv/badger"
 	bpb "github.com/outcaste-io/outserv/badger/pb"
 	"github.com/outcaste-io/ristretto/z"
@@ -44,22 +45,23 @@ var (
 )
 
 type flagOptions struct {
-	testZstd      bool
-	testOpenFiles bool
-	keyLookup     string
-	rollupKey     string
-	parseKey      string
-	keyHistory    bool
-	predicate     string
-	prefix        string
-	readOnly      bool
-	pdir          string
-	itemMeta      bool
-	readTs        uint64
-	sizeHistogram bool
-	namespace     uint64
-	key           x.Sensitive
-	onlySummary   bool
+	testDecompress string
+	testCompress   string
+	testOpenFiles  bool
+	keyLookup      string
+	rollupKey      string
+	parseKey       string
+	keyHistory     bool
+	predicate      string
+	prefix         string
+	readOnly       bool
+	pdir           string
+	itemMeta       bool
+	readTs         uint64
+	sizeHistogram  bool
+	namespace      uint64
+	key            x.Sensitive
+	onlySummary    bool
 
 	// Options related to the WAL.
 	wdir           string
@@ -79,7 +81,10 @@ func init() {
 	Debug.Cmd.SetHelpTemplate(x.NonRootTemplate)
 
 	flag := Debug.Cmd.Flags()
-	flag.BoolVar(&opt.testZstd, "zstd", false, "Reads from stdin, decompress and write to stdout")
+	flag.StringVar(&opt.testDecompress, "decompress", "",
+		"Reads from stdin, decompress and write to stdout. Values are: zstd, snappy, echo")
+	flag.StringVar(&opt.testCompress, "compress", "",
+		"Reads from stdin, compress and write to stdout. Values are: zstd, snappy, echo")
 	flag.BoolVar(&opt.testOpenFiles, "ulimit", false, "Test how many open files can we have.")
 	flag.BoolVar(&opt.itemMeta, "item", true, "Output item meta as well. Set to false for diffs.")
 	flag.Uint64Var(&opt.readTs, "at", math.MaxUint64, "Set read timestamp for all txns.")
@@ -628,9 +633,20 @@ func testOpenFilesLimit() {
 	}
 }
 
-func testZstdDecompress() {
-	reader := zstd.NewReader(os.Stdin)
-	defer reader.Close()
+func testDecompress() {
+	var reader io.Reader
+	switch opt.testDecompress {
+	case "zstd":
+		zr := zstd.NewReader(os.Stdin)
+		defer zr.Close()
+		reader = zr
+	case "snappy":
+		reader = snappy.NewReader(os.Stdin)
+	case "echo":
+		reader = os.Stdin
+	default:
+		log.Fatalf("Invalid option")
+	}
 
 	br := bufio.NewReaderSize(reader, 1<<20)
 	buf := make([]byte, 64<<20)
@@ -646,9 +662,43 @@ func testZstdDecompress() {
 	}
 }
 
+func testCompress() {
+	var writer io.Writer
+	switch opt.testCompress {
+	case "zstd":
+		zw := zstd.NewWriter(os.Stdout)
+		defer zw.Flush()
+		writer = zw
+	case "snappy":
+		sw := snappy.NewBufferedWriter(os.Stdout)
+		defer sw.Flush()
+		writer = sw
+	case "echo":
+		writer = os.Stdout
+	default:
+		log.Fatalf("Invalid option")
+	}
+
+	buf := make([]byte, 64<<20)
+
+	for {
+		n, err := os.Stdin.Read(buf[:cap(buf)])
+		if err == io.EOF {
+			return
+		}
+		x.Check(err)
+		_, err = writer.Write(buf[:n])
+		x.Check(err)
+	}
+}
+
 func run() {
-	if opt.testZstd {
-		testZstdDecompress()
+	if len(opt.testDecompress) > 0 {
+		testDecompress()
+		return
+	}
+	if len(opt.testCompress) > 0 {
+		testCompress()
 		return
 	}
 	if opt.testOpenFiles {

--- a/x/bufreader.go
+++ b/x/bufreader.go
@@ -7,13 +7,13 @@ import (
 )
 
 type BufReader struct {
-	r      io.ReadCloser
+	r      io.Reader
 	curBuf []byte
 	ch     chan []byte
 	bufs   [2][]byte
 }
 
-func NewBufReader(r io.ReadCloser, bufSize int) *BufReader {
+func NewBufReader(r io.Reader, bufSize int) *BufReader {
 	br := &BufReader{
 		r:  r,
 		ch: make(chan []byte), // unbuffered
@@ -26,7 +26,6 @@ func NewBufReader(r io.ReadCloser, bufSize int) *BufReader {
 }
 
 func (br *BufReader) Close() {
-	br.r.Close()
 	for i := 0; i < len(br.bufs); i++ {
 		z.Free(br.bufs[i])
 	}

--- a/x/bufreader.go
+++ b/x/bufreader.go
@@ -7,13 +7,13 @@ import (
 )
 
 type BufReader struct {
-	r      io.Reader
+	r      io.ReadCloser
 	curBuf []byte
 	ch     chan []byte
 	bufs   [2][]byte
 }
 
-func NewBufReader(r io.Reader, bufSize int) *BufReader {
+func NewBufReader(r io.ReadCloser, bufSize int) *BufReader {
 	br := &BufReader{
 		r:  r,
 		ch: make(chan []byte), // unbuffered
@@ -26,6 +26,7 @@ func NewBufReader(r io.Reader, bufSize int) *BufReader {
 }
 
 func (br *BufReader) Close() {
+	br.r.Close()
 	for i := 0; i < len(br.bufs); i++ {
 		z.Free(br.bufs[i])
 	}

--- a/x/bufreader.go
+++ b/x/bufreader.go
@@ -1,0 +1,71 @@
+package x
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type BufReader struct {
+	r      io.Reader
+	u64buf []byte
+	curBuf []byte
+	ch     chan []byte
+	bufs   [2][]byte
+}
+
+func NewBufReader(r io.Reader, bufSize int) *BufReader {
+	br := &BufReader{
+		r:      r,
+		ch:     make(chan []byte), // unbuffered
+		u64buf: make([]byte, binary.MaxVarintLen64),
+	}
+	for i := 0; i < len(br.bufs); i++ {
+		br.bufs[i] = make([]byte, bufSize)
+	}
+	go br.fill()
+	return br
+}
+
+func (br *BufReader) fill() {
+	for i := 0; ; i++ {
+		buf := br.bufs[i%2]
+
+		n, err := io.ReadFull(br.r, buf)
+		if err == io.EOF {
+			close(br.ch)
+			return
+		}
+		if err == io.ErrUnexpectedEOF {
+			buf = buf[:n]
+			br.ch <- buf
+			close(br.ch)
+			return
+		}
+		Check(err)
+		br.ch <- buf
+	}
+}
+
+func (br *BufReader) ReadByte() (byte, error) {
+	var buf [1]byte
+	n, err := br.Read(buf[:])
+	if err != nil {
+		return 0x0, err
+	}
+	AssertTrue(n == 1)
+	return buf[0], nil
+}
+
+func (br *BufReader) Read(p []byte) (int, error) {
+	if len(br.curBuf) == 0 {
+		// check if ch is closed.
+		br.curBuf = <-br.ch
+		if br.curBuf == nil {
+			// channel has been closed.
+			return 0, io.EOF
+		}
+	}
+	n := copy(p, br.curBuf)
+	br.curBuf = br.curBuf[n:]
+	return n, nil
+}


### PR DESCRIPTION
- Switch back to Snappy for compression. It consumes way fewer resources than others.
- Add x.BufReader, which can pre-fetch data from the underlying reader.
- Add a compression / decompression system in debug tool.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/outserv/82)
<!-- Reviewable:end -->
